### PR TITLE
Add ministry query to cakedc users override

### DIFF
--- a/config/tocopy/SimpleCrudTrait.php
+++ b/config/tocopy/SimpleCrudTrait.php
@@ -141,6 +141,9 @@ trait SimpleCrudTrait
      */
     public function edit($id = null)
     {
+        $mins = TableRegistry::getTableLocator()->get('Ministries');
+        $ministries = $mins->find('list');
+
         $table = $this->loadModel();
         $tableAlias = $table->getAlias();
         $entity = $table->get($id, [
@@ -148,6 +151,7 @@ trait SimpleCrudTrait
         ]);
         $this->set($tableAlias, $entity);
         $this->set('tableAlias', $tableAlias);
+        $this->set('ministries', $ministries);
         $this->set('_serialize', [$tableAlias, 'tableAlias']);
         if (!$this->getRequest()->is(['patch', 'post', 'put'])) {
             return;


### PR DESCRIPTION
On the user edit screen, we need a list of ministries in the system so as to assign them if that's necessary. The code to support this resides in one of those files in our config/tocopy folder that needs to overwrite the vendor code as part of the deploy process. I had forgotten to copy the ministry query into the file and this adds it so that the error on the user edit screen goes away :)