### PR TITLE
Update learningcurator-persistent-template.json

### DIFF
--- a/openshift/app/learningcurator-persistent-template.json
+++ b/openshift/app/learningcurator-persistent-template.json
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "kind": "Template",
     "labels": {
       "template": "${APP_NAME}"


### PR DESCRIPTION
Update to apiVersion: template.openshift.io/v1 to accommodate cluster upgrade.