### PR TITLE
Manually fix Azure login add Key encryption

### DIFF
--- a/config/tocopy/Azure.php
+++ b/config/tocopy/Azure.php
@@ -3,6 +3,7 @@
 namespace TheNetworg\OAuth2\Client\Provider;
 
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use League\OAuth2\Client\Grant\AbstractGrant;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
@@ -353,6 +354,7 @@ class Azure extends AbstractProvider
                     $publicKey = $pkey_array ['key'];
 
                     $keys[$keyinfo['kid']] = $publicKey;
+                    $keys[$keyinfo['kid']] = new Key($publicKey, 'RS256');
                 }
             }
         }


### PR DESCRIPTION
As per [this hotfix](https://github.com/spackmat/oauth2-azure/commit/8e8e86274b30e2549ef301f6c5ac64cb336c0982) that references [this issue](https://github.com/TheNetworg/oauth2-azure/issues/161) there's an issue with [outh2 code](https://github.com/TheNetworg/oauth2-azure) we're using where the response token was being passed as a string under php/jwt-5 but php/jwt-6 requires it be encoded. 

This is probably fixed in the actual provider, but then I overwrite it with this now-outdated version. At some point I should do a test install and grab the latest code from it and make my changes to that ...