### PR TITLE
Upgrade to PHP 8.3 image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
           echo "BUILIDING ${APP} with tag: ${BUILD_TAG}"
                 oc -n ${BUILD_NAMESPACE} process -f docker-build.yml \
                 -p TAG=${BUILD_TAG} -p SOURCE_REPOSITORY_REF=${BRANCH} \
-                -p BASE_IMAGE_NAME="php" -p BASE_IMAGE_TAG="7.4-apache" \
+                -p BASE_IMAGE_NAME="php" -p BASE_IMAGE_TAG="8.3-apache" \
                 -p BASE_IMAGE_REPO="aro.jfrog.io/learningcurator/" \
                 -p GITHUB_AUTH_TOKEN=${{secrets.AUTH_TOKEN}} \
                 -p SOURCE_CONTEXT_DIR=. \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.3-apache
 # TODO switch to buster once https://github.com/docker-library/php/issues/865 is resolved in a clean way (either in the PHP image or in PHP itself)
 
 RUN rm -vfr /var/lib/apt/lists/*


### PR DESCRIPTION
I somehow doubt it's going to be this easy, but I have tested the app under PHP 8.? (ages ago, but) and it worked without change, so it's quite possible that simply upgrading the base image will work here.