### PR TITLE
Remove learning centre and antiracism redirect

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -52,6 +52,16 @@ $routes->scope('/', function (RouteBuilder $builder) {
      */
     $builder->connect('/', ['controller' => 'PathwaysUsers', 'action' => 'pathways']);
 
+    // Redirect old page to new location (301)
+    $builder->connect('/p/anti-racism-in-the-british-columbia-public-service', [], [
+        'redirect' => 'https://learningcentre.gww.gov.bc.ca/learninghub/course/anti-racism-in-the-bc-public-service/',
+        'status' => 301
+    ]);
+    $builder->connect('/topic/equity-diversity-and-inclusion/106/anti-racism-in-the-british-columbia-public-service', [], [
+        'redirect' => 'https://learningcentre.gww.gov.bc.ca/learninghub/course/anti-racism-in-the-bc-public-service/',
+        'status' => 301
+    ]);
+
     /*
      * ...and connect the rest of 'Pages' controller's URLs.
      */

--- a/templates/Questions/index.php
+++ b/templates/Questions/index.php
@@ -82,6 +82,13 @@ if ($this->Identity->isLoggedIn()) {
             <?php endif ?>
         <?php endforeach; ?>
         <h4 class="text-xl font-semibold mt-5">Still need help?</h4>
-        <p>If you have unanswered questions about the Learning Curator, we're here to help. Please submit an <a href="https://sfs7.gov.bc.ca/affwebservices/public/saml2sso?SPID=urn:ca:bc:gov:customerportal:prod" class="text-sky-700 hover:underline hover:cursor-pointer" target="_blank">AskMyHR ticket</a> using the "Learning Centre" service category.</p>
+        <p>If you have unanswered questions about the Learning Curator, we're here to help. 
+            Please submit an 
+                <a href="https://sfs7.gov.bc.ca/affwebservices/public/saml2sso?SPID=urn:ca:bc:gov:customerportal:prod" 
+                    class="text-sky-700 hover:underline hover:cursor-pointer" 
+                    target="_blank">
+                        AskMyHR ticket
+                </a> 
+            using the "Corporate Learning" service category.</p>
     </div>
 </div>


### PR DESCRIPTION
Remove reference to Learning Centre from FAQ page and redirect old Anti-racism pathway URL to the LearningHUB listing.